### PR TITLE
Add missing package init files

### DIFF
--- a/agents/ollama/__init__.py
+++ b/agents/ollama/__init__.py
@@ -1,0 +1,5 @@
+"""Ollama agent package exposing computron agent and message handler."""
+from .agents import computron
+from .message_handler import handle_user_message
+
+__all__ = ["computron", "handle_user_message"]

--- a/tools/code/__init__.py
+++ b/tools/code/__init__.py
@@ -1,0 +1,14 @@
+"""Code execution tools package."""
+from .execute_code import (
+    execute_python_program,
+    execute_nodejs_program,
+    execute_nodejs_program_with_playwright,
+)
+from .container_core import CodeExecutionError
+
+__all__ = [
+    "execute_python_program",
+    "execute_nodejs_program",
+    "execute_nodejs_program_with_playwright",
+    "CodeExecutionError",
+]


### PR DESCRIPTION
## Summary
- expose computron+message handler via `agents.ollama`
- add `tools.code` module exports for the executor helpers

## Testing
- `pytest tests/agents/adk -q`
- `pytest tests/agents/ollama/sdk -q`
- `pytest tests/tools -q` *(fails: Execution in container failed: Failed to create/start container)*

------
https://chatgpt.com/codex/tasks/task_e_68674caa2fc483228678924fdb520280