### PR TITLE
feat: add timezone-aware cron scheduling for goals

### DIFF
--- a/agents/goal_planner/agent.py
+++ b/agents/goal_planner/agent.py
@@ -20,7 +20,16 @@ SYSTEM_PROMPT = dedent("""
     WORKFLOW:
     1. Think through the full task graph before calling create_goal.
     2. Call create_goal ONCE with the goal description and ALL tasks in a
-       single call. Add a cron expression if the goal is recurring.
+       single call.
+    3. Add a cron expression if the goal is recurring. When specifying cron,
+       also provide the timezone (e.g., "America/Chicago", "UTC") so the
+       schedule is interpreted correctly.
+
+    CRON AND TIMEZONE:
+    - Use standard 5-field cron syntax: minute hour day-of-month month day-of-week
+    - The timezone parameter is an IANA timezone name like "America/Chicago",
+      "America/New_York", "Europe/London", "UTC", etc.
+    - If omitted, defaults to UTC.
 
     TASK GRAPH RULES:
     - Assign each task a short, descriptive key (e.g. "fetch_data", "analyze").

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -229,6 +229,7 @@ class GoalsConfig(BaseModel):
     max_retries: int = 3
     retry_backoff_base: int = 30
     shutdown_timeout: int = 60
+    timezone: str = "UTC"  # Default timezone for goals (IANA name)
     notifications: NotificationsConfig = Field(default_factory=NotificationsConfig)
     # LLM options for task execution
     model: str = ""  # empty = use server default

--- a/server/aiohttp_app.py
+++ b/server/aiohttp_app.py
@@ -406,7 +406,7 @@ async def _start_task_runner(app: web.Application) -> None:
     from tasks._executor import TaskExecutor
     from tasks._runner import TaskRunner
 
-    store = init_store(goals_dir)
+    store = init_store(goals_dir, default_timezone=config.goals.timezone)
     executor = TaskExecutor(store)
 
     notifier = None

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -18,10 +18,10 @@ from tasks._store import TaskStore
 _store: TaskStore | None = None
 
 
-def init_store(goals_dir: Path) -> FileTaskStore:
+def init_store(goals_dir: Path, default_timezone: str = "UTC") -> FileTaskStore:
     """Initialize the global task store. Call once at startup."""
     global _store  # noqa: PLW0603
-    _store = FileTaskStore(goals_dir)
+    _store = FileTaskStore(goals_dir, default_timezone=default_timezone)
     return _store
 
 

--- a/tasks/_file_store.py
+++ b/tasks/_file_store.py
@@ -63,9 +63,9 @@ class FileTaskStore:
         return json.loads(path.read_text(encoding="utf-8"))
 
 
-    def create_goal(self, description: str, cron: str | None = None, auto_run: bool = True) -> Goal:
+    def create_goal(self, description: str, cron: str | None = None, timezone: str | None = None, auto_run: bool = True) -> Goal:
         """Create a new goal. One-shot goals (no cron) auto-spawn a run unless auto_run=False."""
-        goal = Goal(description=description, cron=cron)
+        goal = Goal(description=description, cron=cron, timezone=timezone or "UTC")
         data = goal.model_dump()
         data["tasks"] = []
         self._write_json(self._goal_path(goal.id), data)

--- a/tasks/_file_store.py
+++ b/tasks/_file_store.py
@@ -364,7 +364,7 @@ class FileTaskStore:
                 (r.completed_at for r in runs if r.completed_at), default=None
             )
             anchor = last_completed or goal.created_at
-            if cron_has_fired_since(goal.cron, anchor):
+            if cron_has_fired_since(goal.cron, anchor, goal.timezone):
                 result.append(goal)
         return result
 

--- a/tasks/_file_store.py
+++ b/tasks/_file_store.py
@@ -27,9 +27,10 @@ class FileTaskStore:
                 └── {run_id}.json
     """
 
-    def __init__(self, base_dir: Path) -> None:
+    def __init__(self, base_dir: Path, default_timezone: str = "UTC") -> None:
         self._base = base_dir
         self._base.mkdir(parents=True, exist_ok=True)
+        self._default_timezone = default_timezone
 
 
     def _goal_path(self, goal_id: str) -> Path:
@@ -65,7 +66,7 @@ class FileTaskStore:
 
     def create_goal(self, description: str, cron: str | None = None, timezone: str | None = None, auto_run: bool = True) -> Goal:
         """Create a new goal. One-shot goals (no cron) auto-spawn a run unless auto_run=False."""
-        goal = Goal(description=description, cron=cron, timezone=timezone or "UTC")
+        goal = Goal(description=description, cron=cron, timezone=timezone or self._default_timezone)
         data = goal.model_dump()
         data["tasks"] = []
         self._write_json(self._goal_path(goal.id), data)

--- a/tasks/_models.py
+++ b/tasks/_models.py
@@ -26,6 +26,7 @@ class Goal(BaseModel):
     description: str
     status: Literal["active", "paused"] = "active"
     cron: str | None = None
+    timezone: str = "UTC"  # IANA timezone name (e.g., "America/Chicago")
     created_at: str = Field(default_factory=_utcnow)
 
 

--- a/tasks/_scheduler.py
+++ b/tasks/_scheduler.py
@@ -3,28 +3,43 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo, available_timezones
 
 from croniter import croniter
 
 
-def cron_has_fired_since(cron_expr: str, anchor: str) -> bool:
+def cron_has_fired_since(cron_expr: str, anchor: str, tz_name: str = "UTC") -> bool:
     """Return True if the cron expression has fired since the anchor time.
 
     Args:
         cron_expr: A standard cron expression (e.g. ``"0 */2 * * *"``).
         anchor: ISO 8601 UTC timestamp to check from.
+        tz_name: IANA timezone name (e.g., "America/Chicago", "UTC").
 
     Returns:
         True if the next fire time after *anchor* is in the past.
     """
+    # Validate and get timezone
+    tz = ZoneInfo(tz_name) if tz_name in available_timezones() else ZoneInfo("UTC")
+    
+    # Parse anchor as UTC, then convert to target timezone
     anchor_dt = datetime.fromisoformat(anchor)
     if anchor_dt.tzinfo is None:
         anchor_dt = anchor_dt.replace(tzinfo=timezone.utc)
-    cron = croniter(cron_expr, anchor_dt)
+    anchor_local = anchor_dt.astimezone(tz)
+    
+    # Evaluate cron in local timezone
+    cron = croniter(cron_expr, anchor_local)
     next_fire = cron.get_next(datetime)
+    
+    # Ensure next_fire has timezone info
     if next_fire.tzinfo is None:
-        next_fire = next_fire.replace(tzinfo=timezone.utc)
-    return next_fire <= datetime.now(timezone.utc)
+        next_fire = next_fire.replace(tzinfo=tz)
+    
+    # Convert back to UTC for comparison
+    next_fire_utc = next_fire.astimezone(timezone.utc)
+    
+    return next_fire_utc <= datetime.now(timezone.utc)
 
 
 __all__ = ["cron_has_fired_since"]

--- a/tasks/_store.py
+++ b/tasks/_store.py
@@ -14,7 +14,13 @@ class TaskStore(Protocol):
     file-based to SQLite (or another backend) by implementing this protocol.
     """
 
-    def create_goal(self, description: str, cron: str | None = None, auto_run: bool = True) -> Goal:
+    def create_goal(
+        self,
+        description: str,
+        cron: str | None = None,
+        timezone: str | None = None,
+        auto_run: bool = True,
+    ) -> Goal:
         """Create a new goal. One-shot goals (no cron) auto-spawn a run unless auto_run=False."""
         ...
 

--- a/tasks/_tools.py
+++ b/tasks/_tools.py
@@ -9,6 +9,7 @@ async def create_goal(
     description: str,
     tasks: list[dict[str, Any]],
     cron: str | None = None,
+    timezone: str | None = None,
 ) -> str:
     """Create a goal with all its tasks in a single call.
 
@@ -33,6 +34,8 @@ async def create_goal(
               depends on.
         cron: Cron expression for recurring goals (e.g. '0 */2 * * *').
             Omit for one-shot goals, which spawn a run immediately.
+        timezone: IANA timezone name (e.g. 'America/Chicago', 'UTC').
+            Uses the config default if not specified.
     """
     if not description or not description.strip():
         return "Error: description is required and cannot be empty."
@@ -68,7 +71,12 @@ async def create_goal(
                 )
 
     store = get_store()
-    goal = store.create_goal(description=description.strip(), cron=cron, auto_run=False)
+    goal = store.create_goal(
+        description=description.strip(),
+        cron=cron,
+        timezone=timezone,
+        auto_run=False,
+    )
 
     key_to_id: dict[str, str] = {}
     from tasks._models import _new_id
@@ -101,7 +109,8 @@ async def create_goal(
         lines.append(f"  - [{key}] {task.description} (id={task.id}, agent={task.agent}{deps_note})")
 
     task_lines = "\n".join(lines)
-    return f"Created goal '{goal.description}' (id={goal.id}) with {len(created_tasks)} task(s):\n{task_lines}"
+    tz_note = f", timezone={goal.timezone}" if goal.timezone else ""
+    return f"Created goal '{goal.description}' (id={goal.id}{tz_note}) with {len(created_tasks)} task(s):\n{task_lines}"
 
 
 async def list_goals(status: str | None = None) -> str:
@@ -114,7 +123,7 @@ async def list_goals(status: str | None = None) -> str:
     goals = store.list_goals(status=status)
     if not goals:
         return "No goals found."
-    lines = [f"- {g.description} (id={g.id}, status={g.status}, cron={g.cron})" for g in goals]
+    lines = [f"- {g.description} (id={g.id}, status={g.status}, cron={g.cron}, timezone={g.timezone})" for g in goals]
     return "\n".join(lines)
 
 

--- a/tests/tasks/test_file_store.py
+++ b/tests/tasks/test_file_store.py
@@ -26,6 +26,23 @@ class TestGoalCRUD:
         assert retrieved.id == goal.id
         assert retrieved.description == goal.description
 
+
+    def test_create_goal_with_timezone(self, store):
+        """Create a goal with a specific timezone."""
+        goal = store.create_goal("test goal", cron="0 * * * *", timezone="America/Chicago")
+        assert goal.timezone == "America/Chicago"
+
+        retrieved = store.get_goal(goal.id)
+        assert retrieved.timezone == "America/Chicago"
+
+    def test_create_goal_timezone_defaults_to_utc(self, store):
+        """Goal timezone defaults to UTC when not specified."""
+        goal = store.create_goal("test goal")
+        assert goal.timezone == "UTC"
+
+        retrieved = store.get_goal(goal.id)
+        assert retrieved.timezone == "UTC"
+
     def test_list_goals(self, store):
         """List all goals."""
         store.create_goal("goal 1")

--- a/tests/tasks/test_tools.py
+++ b/tests/tasks/test_tools.py
@@ -188,3 +188,14 @@ class TestListTools:
         goal_id = _extract_id(await create_goal("goal", tasks=[_TASK]))
         result = await list_tasks(goal_id)
         assert "task 1" in result
+
+    async def test_timezone_default_to_utc(self):
+        """Goal timezone defaults to UTC."""
+        result = await create_goal("goal with tz", tasks=[_TASK])
+        assert "timezone=UTC" in result
+
+    async def test_timezone_parameter(self):
+        """Goal timezone is set when provided."""
+        result = await create_goal("goal with tz", tasks=[_TASK], cron="0 * * * *", timezone="America/Chicago")
+        assert "timezone=America/Chicago" in result
+


### PR DESCRIPTION
🤖 _This PR was created by COMPUTRON_9000._ 🤖

🌍 **Timezone-Aware Cron Scheduling for Goals**

✨ What's new:
- 🕐 Add timezone field to Goal model (IANA timezone names)
- ⏰ Update scheduler to evaluate cron in local timezone
- ⚙️ Add default timezone config option in GoalsConfig
- 🔌 Wire up GoalsConfig.timezone to FileTaskStore as default
- 🛠️ Add timezone parameter to create_goal tool
- 📖 Update GOAL_PLANNER agent system prompt with timezone documentation

🎯 Goals now respect user-specified timezone instead of UTC-only

💡 **Example:** cron '0 8 * * 1' with timezone 'America/Chicago' now runs at 8 AM Central Time, not 3 AM UTC.