### PR TITLE
Fix Optional type detection in _python_type_to_json_schema

### DIFF
--- a/sdk/providers/_tool_schema.py
+++ b/sdk/providers/_tool_schema.py
@@ -7,8 +7,9 @@ for tool definitions (unlike Ollama which accepts raw callables).
 import inspect
 import logging
 import re
+import types
 from collections.abc import Callable
-from typing import Any, get_args, get_origin
+from typing import Any, Union, get_args, get_origin
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ def _python_type_to_json_schema(annotation: Any) -> dict[str, Any]:
         return {"type": "object"}
 
     # Handle Optional (Union[X, None])
-    if origin is type(int | None):
+    if origin is Union or origin is types.UnionType:
         args = [a for a in get_args(annotation) if a is not type(None)]
         if len(args) == 1:
             return _python_type_to_json_schema(args[0])


### PR DESCRIPTION
## Summary

Fixed a bug in the `_python_type_to_json_schema` function where the Optional type detection only worked for the new-style union syntax (`X | None`) but failed for `typing.Optional[X]` or `Union[X, None]`.

## Bug Details

**File:** `sdk/providers/_tool_schema.py`
**Line:** 105

**Before:**
```python
if origin is type(int | None):
```

This check incorrectly assumed that `type(int | None)` uniquely identifies Optional types, but this only matches the `types.UnionType` class, not the `typing.Union` used by `typing.Optional`.

**After:**
```python
if origin is Union or origin is types.UnionType:
```

This correctly handles both:
- `typing.Optional[X]` (origin is `typing.Union`)
- `X | None` (origin is `types.UnionType`)

## Impact

With the bug, function parameters using `Optional[int]`, `Optional[str]`, etc. would incorrectly be treated as generic `string` types in JSON schema, losing the actual type information.

## Testing

All 34 existing tests in `tests/sdk/providers/test_tool_schema.py` pass, and manual verification confirms both Optional syntaxes now work correctly:

- `int | None` → {"type": "integer"}
- `Optional[int]` → {"type": "integer"}
- `str | None` → {"type": "string"}
- `Optional[str]` → {"type": "string"}