### PR TITLE
Fix: Add missing aiohttp_client fixture for server tests

### DIFF
--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,0 +1,34 @@
+"""Pytest configuration for server tests.
+
+Provides the aiohttp_client fixture for testing aiohttp applications.
+"""
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+
+@pytest.fixture
+async def aiohttp_client():
+    """Fixture factory that returns a test client for aiohttp apps.
+    
+    Usage:
+        async def test_something(aiohttp_client, app):
+            client = await aiohttp_client(app)
+            resp = await client.get('/')
+            ...
+    """
+    clients: list[TestClient] = []
+    
+    async def _create_client(app: web.Application) -> TestClient:
+        server = TestServer(app)
+        client = TestClient(server)
+        await client.start_server()
+        clients.append(client)
+        return client
+    
+    yield _create_client
+    
+    # Cleanup: close all clients
+    for client in clients:
+        await client.close()


### PR DESCRIPTION
## Bug Description

The server tests in  were failing with a 'fixture "'aiohttp_client'" not found' error because the  fixture required by  was not being provided.

## Changes Made

Added  with a proper  fixture that:
- Creates / instances for testing aiohttp applications
- Properly cleans up client sessions after tests (preventing resource leaks)
- Works with existing tests in 

## Test Results

Before this fix:


After this fix:


All 6 server tests now pass (test_routes_exist, test_validation_error_returns_400, test_streaming_chat, test_delete_history, test_streams_agent_event_objects_and_closes, test_streaming_includes_enriched_fields).