### PR TITLE
fix: remove unreachable code and duplicate import in run_bash_cmd.py

### DIFF
--- a/tools/virtual_computer/run_bash_cmd.py
+++ b/tools/virtual_computer/run_bash_cmd.py
@@ -9,7 +9,7 @@ import json
 import logging
 import re
 import uuid
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from podman import PodmanClient
 from podman.api import stream_frames
@@ -20,9 +20,6 @@ from sdk.events import AgentEvent, TerminalOutputPayload, publish_event
 from tools._truncation import truncate_args
 from config import load_config
 from tools.virtual_computer.workspace import get_current_workspace_folder
-
-if TYPE_CHECKING:
-    from podman.domain.containers import Container
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +98,6 @@ async def run_bash_cmd(cmd: str, timeout: float = BASH_CMD_TIMEOUT) -> BashCmdRe
         container: Container | None = next((c for c in containers if c.name == container_name), None)
         if container is None:
             _raise_container_not_found(container_name)
-            return BashCmdResult(stdout=None, stderr=None, exit_code=None)
 
         # Add strict flags to ensure one-shot behavior
         strict_cmd = f"set -euo pipefail; {cmd}"


### PR DESCRIPTION
## Summary

Fixed unreachable code and duplicate imports in `tools/virtual_computer/run_bash_cmd.py`.

## What was changed

**File:** `tools/virtual_computer/run_bash_cmd.py`

**Changes (3 fixes):**

1. **Line 104:** Removed unreachable `return` statement after `_raise_container_not_found()` 
   - The function `_raise_container_not_found()` always raises a `RunBashCmdError` exception, making the return statement unreachable
   - This was dead code that could never execute

2. **Lines 24-25:** Removed redundant `TYPE_CHECKING` block
   - The `Container` type was already imported at runtime on line 16
   - The `TYPE_CHECKING` conditional import was unnecessary and confusing

3. **Line 12:** Removed unused `TYPE_CHECKING` import from `typing`
   - After removing the conditional import block, this import became unused

## Why this was a bug

- **Unreachable code:** The `return BashCmdResult(stdout=None, stderr=None, exit_code=None)` statement could never be reached since `_raise_container_not_found()` always raises an exception
- **Dead code maintenance:** Removing dead code reduces confusion for developers reading the code
- **Import clarity:** The duplicate/conditional import pattern was unnecessary since `Container` is imported at runtime anyway

## Testing done

- `tests/tools/virtual_computer/test_run_bash_cmd_policy.py` - 10 tests passed
- `tests/tools/virtual_computer/test_run_bash_cmd_streaming.py` - 1 test passed
- Python syntax validation passed
- No functional behavior changes - purely code cleanup