### PR TITLE
fix: remove unused asyncio import from aiohttp_app.py

### DIFF
--- a/server/aiohttp_app.py
+++ b/server/aiohttp_app.py
@@ -23,8 +23,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from aiohttp.web_request import Request
     from aiohttp.web_response import Response, StreamResponse
 
-import asyncio
-
 from server.message_handler import AVAILABLE_AGENTS, handle_user_message, reset_message_history, resume_conversation
 from sdk.providers import get_provider
 from sdk.turn import is_turn_active, queue_nudge, request_stop


### PR DESCRIPTION
## Description

Removes the unused `asyncio` import from `server/aiohttp_app.py`.

## Details

- **File:** `server/aiohttp_app.py`
- **Line:** 26
- **Issue:** The `asyncio` module was imported but never used anywhere in the file
- **Fix:** Removed the unused `import asyncio` statement

This is a minor code cleanup that removes dead code and improves maintainability.