### PR TITLE
fix: fix garbled character in Justfile Variables section header

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -11,7 +11,7 @@ default:
 
 
 # =============================================
-# � Variables
+# 📦 Variables
 # =============================================
 # Centralize UI directory path to avoid repetition
 UI_DIR := "server/ui"


### PR DESCRIPTION
## What was changed

**File:** `Justfile` (line 14)

**Change:**
- Replaced garbled character � with proper package emoji 📦 in the Variables section header

```diff
- # � Variables
+ # 📦 Variables
```

## Why it was a bug

The Variables section header in the Justfile contained a garbled character (U+FFFD replacement character) instead of the intended emoji/character. This:
1. Makes the file look broken or corrupted when viewed
2. Could cause display issues in different terminal environments
3. Looks unprofessional in the codebase

## What the fix does

Replaced the garbled character with a clear package emoji (📦) that:
- Properly displays across modern terminals and editors
- Clearly indicates this is the Variables section
- Matches the style of other section headers in the file

## Testing done

- Verified the character displays correctly in terminal with `cat` command
- Confirmed file encoding remains UTF-8
- Ran `just --list` to ensure the Justfile still parses correctly
