### PR TITLE
fix(sdk): Add runtime deprecation warning to OllamaTokenCounter

### DIFF
--- a/sdk/context/_token_tracker.py
+++ b/sdk/context/_token_tracker.py
@@ -1,5 +1,6 @@
 """Pluggable token counting and cumulative tracking."""
 
+import warnings
 from typing import Any, Protocol
 
 from ._models import ContextStats, TokenUsage
@@ -20,6 +21,13 @@ class OllamaTokenCounter:
         Use ``ChatResponseTokenCounter`` instead, which works with the
         normalized ``ChatResponse`` from any provider.
     """
+
+    def __init__(self) -> None:
+        warnings.warn(
+            "OllamaTokenCounter is deprecated, use ChatResponseTokenCounter instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     def extract_usage(self, response: Any) -> TokenUsage:
         """Read ``prompt_eval_count`` and ``eval_count`` from the response."""


### PR DESCRIPTION
## Summary

The <code>OllamaTokenCounter</code> class had a docstring with <code>.. deprecated::</code> directive but no runtime deprecation warning was emitted. This change adds a proper Python <code>DeprecationWarning</code> using <code>warnings.warn()</code> when the class is instantiated.

## Issue

The class documentation indicated deprecation, but users would only discover this by reading the source code or documentation. There was no runtime notification to guide users toward the replacement class.

## Fix

- Added <code>import warnings</code> at module level
- Added <code>__init__</code> method with <code>warnings.warn()</code> call
- Used <code>stacklevel=2</code> for accurate warning source location

## Verification

- All existing tests pass (7/7)
- Deprecation warnings are now properly emitted at runtime
- Functional behavior remains unchanged

## Migration Path

Users should replace:
<code>OllamaTokenCounter()</code> with <code>ChatResponseTokenCounter()</code>