### PR TITLE
Store TELEGRAM_BOT_TOKEN as instance variable for consistency

### DIFF
--- a/tasks/_notifier.py
+++ b/tasks/_notifier.py
@@ -27,9 +27,9 @@ class TelegramNotifier:
 
     def __init__(self, config: NotificationsConfig) -> None:
         self._config = config
-        token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+        self._token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
         self._chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
-        if not token or not self._chat_id:
+        if not self._token or not self._chat_id:
             logger.warning(
                 "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set — "
                 "Telegram notifications disabled"
@@ -38,7 +38,7 @@ class TelegramNotifier:
             self._base_url = ""
             return
         self._disabled = False
-        self._base_url = f"https://api.telegram.org/bot{token}"
+        self._base_url = f"https://api.telegram.org/bot{self._token}"
 
     @property
     def enabled(self) -> bool:


### PR DESCRIPTION
## Summary

Fixed an inconsistency in TelegramNotifier.__init__ where TELEGRAM_BOT_TOKEN was read into a local variable while TELEGRAM_CHAT_ID was stored as an instance variable.

## Changes

- Line 30: Changed token = os.environ.get(...) to self._token = os.environ.get(...)
- Line 32: Updated condition check from not token to not self._token
- Line 41: Updated URL construction to use self._token instead of token

## Why

This change improves code consistency (both token and chat_id are now stored as instance variables) and allows potential future use cases like re-initialization, debugging, or extension.

## Files Changed

- tasks/_notifier.py