### PR TITLE
Add missing from __future__ import annotations to sdk/context/_models.py

### DIFF
--- a/sdk/context/_models.py
+++ b/sdk/context/_models.py
@@ -1,5 +1,7 @@
 """Data models for context management."""
 
+from __future__ import annotations
+
 from pydantic import BaseModel
 
 


### PR DESCRIPTION
## Summary

Adds the missing `from __future__ import annotations` import to `sdk/context/_models.py` that is present in almost all other Python files in the codebase.

## Changes

- Added `from __future__ import annotations` import for consistency with the rest of the codebase

## Why

This import is standard across the codebase and ensures:
1. Forward compatibility with modern Python type hint syntax (e.g., `int | None` instead of `Optional[int]`)
2. Consistency with other files in the `sdk/context/` directory and the project as a whole
3. Proper behavior of postponed evaluation of annotations (PEP 563)

## Testing

- File parses correctly with Python 3.11
- No functional changes to the code