### PR TITLE
Fix synchronous file I/O in Telegram notifier

### DIFF
--- a/tasks/_notifier.py
+++ b/tasks/_notifier.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -89,13 +90,14 @@ class TelegramNotifier:
                 path,
             )
             return
+        # Read file content in thread to avoid blocking the event loop
+        content = await asyncio.to_thread(path.read_bytes)
         async with httpx.AsyncClient(timeout=120) as client:
-            with open(path, "rb") as f:
-                resp = await client.post(
-                    f"{self._base_url}/sendDocument",
-                    data={"chat_id": self._chat_id},
-                    files={"document": (path.name, f)},
-                )
+            resp = await client.post(
+                f"{self._base_url}/sendDocument",
+                data={"chat_id": self._chat_id},
+                files={"document": (path.name, content)},
+            )
             if resp.status_code != 200:
                 logger.error(
                     "Telegram sendDocument failed (%d): %s",


### PR DESCRIPTION
## Summary
Fixes synchronous file I/O blocking inside an async method in the Telegram notifier.

## What was changed
- **File:** tasks/_notifier.py
- **Lines:** 89-102 (the _send_document method)

### Before (problematic code):
```python
async with httpx.AsyncClient(timeout=120) as client:
    with open(path, "rb") as f:
        resp = await client.post(...)
```

### After (fixed code):
```python
# Read file content in thread to avoid blocking the event loop
content = await asyncio.to_thread(path.read_bytes)
async with httpx.AsyncClient(timeout=120) as client:
    resp = await client.post(
        f"{self._base_url}/sendDocument",
        data={"chat_id": self._chat_id},
        files={"document": (path.name, content)},
    )
```

## Why it was a bug
The original code used a synchronous open() and read() call inside an async method (_send_document), which blocks the event loop when reading large files from disk. This can cause the entire async application to freeze while waiting for I/O operations to complete.

## What the fix does
- Uses asyncio.to_thread() to offload file I/O to a separate thread
- Reads file content asynchronously using path.read_bytes()
- Maintains the same functionality while preventing event loop blocking

## Testing done
- All 77 tests in the tasks/ directory pass
- All 6 notifier-specific tests pass:
  - test_enables_when_env_vars_present
  - test_send_noop_when_disabled
  - test_send_calls_telegram_api
  - test_send_document
  - test_skips_large_files
  - test_send_does_not_raise_on_error
