### PR TITLE
Fix outdated docstring in async_lru_cache decorator

### DIFF
--- a/utils/cache.py
+++ b/utils/cache.py
@@ -49,10 +49,8 @@ def async_lru_cache(
     If any argument is not hashable, a TypeError is raised.
 
     Args:
-        maxsize (int): Maximum size of the LRU cache. Default is 10.
-        ttl (float | None): Optional time-to-live in seconds for cache entries.
-            If provided and > 0, entries expire after `ttl` seconds. If None or
-            <= 0, only LRU-based eviction is used.
+        ttl (float): Time-to-live in seconds for cache entries. Default is 60.0.
+            Entries expire after `ttl` seconds.
 
     Returns:
         Callable: Decorated async function.


### PR DESCRIPTION
## Summary

Fixed an outdated docstring in `utils/cache.py` that incorrectly documented a `maxsize` parameter that doesn't exist in the function signature.

## Changes

- Removed the non-existent `maxsize` parameter from the docstring
- Updated the `ttl` parameter documentation to accurately reflect its purpose and default value

## Details

The `async_lru_cache` decorator only accepts a `ttl` parameter (default: 60.0 seconds), but the docstring incorrectly mentioned a `maxsize` parameter with a default of 10. This was misleading documentation that could confuse developers using the function.

The implementation uses `cachetools.TTLCache(maxsize=1, ttl=ttl)` internally, but the `maxsize` is hardcoded to 1 and not exposed as a parameter.