### PR TITLE
fix: add missing Task and TaskResult type imports in _runner.py

### DIFF
--- a/tasks/_runner.py
+++ b/tasks/_runner.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from config import GoalsConfig
     from tasks._executor import TaskExecutor
+    from tasks._models import Task, TaskResult
     from tasks._notifier import TelegramNotifier
     from tasks._store import TaskStore
 


### PR DESCRIPTION
## Summary

Fixes undefined name errors (F821) detected by ruff in `tasks/_runner.py`.

## Problem

The `_execute` method in `TaskRunner` uses `TaskResult` and `Task` in its type signature as string forward references, but these types were not imported in the `TYPE_CHECKING` block. This causes:

- F821 Undefined name `TaskResult` at line 124
- F821 Undefined name `Task` at line 124

## Solution

Added `Task` and `TaskResult` imports from `tasks._models` to the `TYPE_CHECKING` block.

## Changes

- `tasks/_runner.py`: Added missing imports (1 line change)

## Verification

- [x] ruff check passes (F821 errors resolved)
- [x] All 79 tasks module tests pass
- [x] Import works correctly at runtime