### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware datetime.now(UTC)

### DIFF
--- a/sdk/events/_models.py
+++ b/sdk/events/_models.py
@@ -14,7 +14,7 @@ Design notes:
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
@@ -279,7 +279,7 @@ class AgentEvent(BaseModel):
     """
 
     payload: AgentEventPayload
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     agent_name: str | None = None
     agent_id: str | None = None
     depth: int | None = None

--- a/tests/sdk/events/test_models.py
+++ b/tests/sdk/events/test_models.py
@@ -6,7 +6,7 @@ event payloads, default values, and JSON-serializable output shape.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -25,9 +25,9 @@ def test_agent_event_defaults():
     Validates that metadata fields default to None and a timestamp is set.
     """
 
-    before = datetime.utcnow()
+    before = datetime.now(UTC)
     resp = AgentEvent(payload=ContentPayload(type="content"))
-    after = datetime.utcnow()
+    after = datetime.now(UTC)
 
     assert resp.payload.type == "content"
     assert resp.payload.content is None


### PR DESCRIPTION
## Summary

Replaces the deprecated `datetime.utcnow()` with `datetime.now(UTC)` to ensure compatibility with Python 3.12+.

## Changes Made

### sdk/events/_models.py (Line 17, 282)
- Added `UTC` to the datetime import
- Changed default factory from `datetime.utcnow` to `lambda: datetime.now(UTC)`

### tests/sdk/events/test_models.py (Line 9, 28, 30)
- Added `UTC` to the datetime import
- Updated test assertions to use `datetime.now(UTC)` instead of `datetime.utcnow()`

## Why This Fix Was Needed

`datetime.utcnow()` is deprecated in Python 3.12+ and will be removed in future versions. Using timezone-aware datetime objects is the recommended approach.

## Testing

All 4 tests in `tests/sdk/events/test_models.py` pass:
- `test_agent_event_defaults`
- `test_tool_call_event_embedding`
- `test_content_payload_fields`
- `test_turn_end_payload`