### PR TITLE
fix: export AgentEventBufferHook from sdk.hooks

### DIFF
--- a/sdk/hooks/__init__.py
+++ b/sdk/hooks/__init__.py
@@ -12,6 +12,7 @@ Phase signatures:
     on_turn_end(final_content, agent_name) -> None
 """
 
+from ._agent_event_buffer import AgentEventBufferHook
 from ._budget_guard import BudgetGuard
 from ._context_hook import ContextHook
 from ._default import default_hooks
@@ -25,6 +26,7 @@ from ._scratchpad_hook import ScratchpadHook
 from ._stop_hook import StopHook
 
 __all__ = [
+    "AgentEventBufferHook",
     "BudgetGuard",
     "ContextHook",
     "LoadedSkillHook",


### PR DESCRIPTION
## Summary

Fixes missing export of `AgentEventBufferHook` from the `sdk.hooks` module.

## What Changed

**File:** `sdk/hooks/__init__.py`

- **Line 15:** Added import `from ._agent_event_buffer import AgentEventBufferHook`
- **Line 29:** Added `"AgentEventBufferHook",` to `__all__` list

## Why This Was a Bug

`AgentEventBufferHook` was implemented in `sdk/hooks/_agent_event_buffer.py` but was not exported from the public `sdk.hooks` module. This caused an API inconsistency where:
- All other hooks (`BudgetGuard`, `ContextHook`, `StopHook`, etc.) were importable via `from sdk.hooks import ...`
- `AgentEventBufferHook` required importing from the private module `sdk.hooks._agent_event_buffer`

## What the Fix Does

- Enables proper public API access: `from sdk.hooks import AgentEventBufferHook`
- Maintains alphabetical ordering in both imports and `__all__` list
- Follows the existing pattern used by all other hook exports

## Testing Done

- ✅ Import test passed: `from sdk.hooks import AgentEventBufferHook` works correctly
- ✅ All 20 hook-related tests pass
- ✅ No breaking changes introduced