### PR TITLE
fix(browser): support contenteditable elements in fill_field and DOM walker

### DIFF
--- a/tools/browser/core/page_view.py
+++ b/tools/browser/core/page_view.py
@@ -96,7 +96,7 @@ _STRUCTURED_SNAPSHOT_JS = """
   function getRole(el) {
     const explicit = el.getAttribute('role');
     if (explicit) return explicit;
-    if (el.getAttribute('contenteditable') === 'true') return 'textbox';
+    if (el.isContentEditable) return 'textbox';
     const tag = el.tagName;
     switch (tag) {
       case 'A': return el.hasAttribute('href') ? 'link' : null;

--- a/tools/browser/core/page_view.py
+++ b/tools/browser/core/page_view.py
@@ -96,6 +96,7 @@ _STRUCTURED_SNAPSHOT_JS = """
   function getRole(el) {
     const explicit = el.getAttribute('role');
     if (explicit) return explicit;
+    if (el.getAttribute('contenteditable') === 'true') return 'textbox';
     const tag = el.tagName;
     switch (tag) {
       case 'A': return el.hasAttribute('href') ? 'link' : null;

--- a/tools/browser/interactions.py
+++ b/tools/browser/interactions.py
@@ -391,9 +391,7 @@ async def fill_field(selector: str, value: str | int | float | bool | None) -> s
             if tag_name == "input":
                 raw_type = await handle.get_attribute("type")
                 input_type = (raw_type or "text").lower()
-            is_contenteditable = await handle.evaluate(
-                "el => el.getAttribute('contenteditable') === 'true'"
-            )
+            is_contenteditable = await handle.evaluate("el => el.isContentEditable")
     except PlaywrightError as exc:  # pragma: no cover - defensive introspection aid
         logger.debug("Failed to introspect element for fill_field: %s", exc)
 

--- a/tools/browser/interactions.py
+++ b/tools/browser/interactions.py
@@ -383,6 +383,7 @@ async def fill_field(selector: str, value: str | int | float | bool | None) -> s
 
     tag_name = ""
     input_type = ""
+    is_contenteditable = False
     try:
         handle = await locator.element_handle(timeout=5000)
         if handle is not None:
@@ -390,11 +391,14 @@ async def fill_field(selector: str, value: str | int | float | bool | None) -> s
             if tag_name == "input":
                 raw_type = await handle.get_attribute("type")
                 input_type = (raw_type or "text").lower()
+            is_contenteditable = await handle.evaluate(
+                "el => el.getAttribute('contenteditable') === 'true'"
+            )
     except PlaywrightError as exc:  # pragma: no cover - defensive introspection aid
         logger.debug("Failed to introspect element for fill_field: %s", exc)
 
-    if tag_name not in {"input", "textarea"}:
-        msg = "fill_field only supports input and textarea elements"
+    if tag_name not in {"input", "textarea"} and not is_contenteditable:
+        msg = "fill_field only supports input, textarea, and contenteditable elements"
         raise BrowserToolError(msg, tool="fill_field", details=details)
 
     unsupported_inputs = {"checkbox", "radio", "submit", "button", "image", "file", "hidden"}


### PR DESCRIPTION
## Problem

CodeMirror and other rich-text editors render their editing surface as a . During the browser stress test, this caused two failures on [codemirror.net](https://codemirror.net):

1. **DOM walker ignored the editor** —  only checked explicit  attributes and known tag names (, , etc.). It never looked at , so the editor was not assigned a ref number and did not appear in  output.

2. ** rejected the editor** — Even if a user somehow targeted the element,  hard-coded its allowed tag list to  and raised  for anything else.

## Changes

- **** —  now returns  when .
- **** —  introspects the element for  and allows it alongside  and .

## Verification

-  now shows the CodeMirror editor as .
-  successfully types into the editor.

## Scope

This PR only addresses Issue 1 (contenteditable). Issues 2–4 from the stress test (slider naming, SPA hydration, iframe traversal) are left for follow-up PRs.

Fixes partial failure on codemirror.net and similar rich-text editors.