### PR TITLE
fix(browser): replace ad-hoc name exemptions with NAME_REQUIRED sets

### DIFF
--- a/tools/browser/core/_pipeline.py
+++ b/tools/browser/core/_pipeline.py
@@ -21,6 +21,12 @@ from tools.browser.core._dom_nodes import (
 )
 from tools.browser.core.site_filters import filter_for_site
 
+# Roles that are meaningless without an accessible name (ARIA "name from content").
+# All other interactive roles carry value/state and are actionable even nameless.
+NAME_REQUIRED_ROLES = frozenset({
+    "link", "button", "tab", "menuitem", "option", "treeitem"
+})
+
 __all__ = ["process_snapshot"]
 
 
@@ -182,8 +188,8 @@ def _render_node(node: DomNode, *, name_limit: int) -> str | None:
         name = (node.name or "").strip()
         value = (node.value or "").strip()
 
-        # Nameless comboboxes are allowed, others require a name
-        if not name and role not in ("combobox",):
+        # Roles that are meaningless without an accessible name are skipped
+        if not name and role in NAME_REQUIRED_ROLES:
             return None
 
         name_display = _truncate(name, name_limit) if name else ""

--- a/tools/browser/core/page_view.py
+++ b/tools/browser/core/page_view.py
@@ -129,6 +129,12 @@ _STRUCTURED_SNAPSHOT_JS = """
     'option','treeitem'
   ]);
 
+  // Roles that are meaningless without an accessible name (ARIA "name from content").
+  // All other INTERACTIVE roles carry value/state and are actionable even nameless.
+  const NAME_REQUIRED = new Set([
+    'link', 'button', 'tab', 'menuitem', 'option', 'treeitem'
+  ]);
+
   // ---- Accessible name ----
   function getName(el) {
     const al = el.getAttribute('aria-label');
@@ -363,7 +369,7 @@ _STRUCTURED_SNAPSHOT_JS = """
     // Interactive elements: stamp with ref, emit node data
     if (role && INTERACTIVE.has(role)) {
       let name = getName(el);
-      if (!name && role !== 'combobox' && el.tagName !== 'SELECT') return;
+      if (!name && NAME_REQUIRED.has(role)) return;
 
       refCounter++;
       el.setAttribute('data-ct-ref', String(refCounter));


### PR DESCRIPTION
## Problem

The browser tool's DOM walker (`page_view.py`) and Python renderer (`_pipeline.py`) each had independent name-check gates that used ad-hoc exemption chains:

- JS walker: `if (!name && role !== 'combobox' && el.tagName !== 'SELECT') return;`
- Python renderer: `if not name and role not in ("combobox",): return None`

This caused jQuery UI sliders (`<span role="slider">` with no accessible name) and other stateful controls (checkboxes, radios, switches, spinbuttons) to be **silently skipped** when they lacked accessible names. They never got a `data-ct-ref` stamp and never appeared in the page snapshot.

## Solution

Replace the ad-hoc exemptions with a shared semantic criterion: **ARIA "name from content" roles**.

Roles that are meaningless without text (link, button, tab, menuitem, option, treeitem) are dropped when nameless. All other interactive roles carry value/state and are actionable even without a name.

### Changes

- **`tools/browser/core/page_view.py`** — Added `NAME_REQUIRED` set. The walker now only drops nameless elements whose role is in this set.
- **`tools/browser/core/_pipeline.py`** — Added matching `NAME_REQUIRED_ROLES` frozenset. The renderer uses the same criteria, eliminating silent drops from gate mismatches.

### Also fixed

- Removes the redundant `el.tagName !== 'SELECT'` check. `<select>` always resolves to `role='combobox'`, which is not in `NAME_REQUIRED`.

### Result

| Role | Before | After |
|------|--------|-------|
| `slider` | ❌ invisible | ✅ visible |
| `checkbox` | ❌ invisible | ✅ visible |
| `radio` | ❌ invisible | ✅ visible |
| `switch` | ❌ invisible | ✅ visible |
| `spinbutton` | ❌ invisible | ✅ visible |
| `textbox` | ❌ invisible | ✅ visible |
| `searchbox` | ❌ invisible | ✅ visible |
| `combobox` | ✅ visible | ✅ visible |
| `button` (nameless) | ❌ invisible | ❌ invisible |
| `link` (nameless) | ❌ invisible | ❌ invisible |

Fixes partial failure on jqueryui.com/slider and similar widgets.