### PR TITLE
fix: replace sync subprocess.run with async create_subprocess_exec in…

### DIFF
--- a/sdk/context/_strategy.py
+++ b/sdk/context/_strategy.py
@@ -288,11 +288,11 @@ class LLMCompactionStrategy:
                 "LLMCompactionStrategy: compaction timed out after %ds, skipping",
                 _CALL_TIMEOUT,
             )
-            _unload_model(resolved_model)
+            await _unload_model(resolved_model)
             return
         except Exception:
             logger.exception("LLMCompactionStrategy: LLM call failed, skipping compaction")
-            _unload_model(resolved_model)
+            await _unload_model(resolved_model)
             return
         elapsed = _time.monotonic() - t0
 
@@ -368,7 +368,7 @@ class LLMCompactionStrategy:
             pinned_msg["content"] = _INTENT_PREFIX + intent_history
 
         # Unload the summarizer model to free VRAM for the main agent.
-        _unload_model(model_name)
+        await _unload_model(model_name)
 
     async def _summarize(
         self,
@@ -520,14 +520,20 @@ class LLMCompactionStrategy:
         return None
 
 
-def _unload_model(model: str) -> None:
+async def _unload_model(model: str) -> None:
     """Unload a model from Ollama to free VRAM."""
-    import subprocess
     try:
-        subprocess.run(
-            ["ollama", "stop", model],
-            capture_output=True, timeout=30,
+        proc = await asyncio.create_subprocess_exec(
+            "ollama", "stop", model,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
+        try:
+            await asyncio.wait_for(proc.communicate(), timeout=30)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            logger.debug("Unload model %s timed out after 30s", model)
     except Exception:
         logger.debug("Failed to unload model %s", model)
 

--- a/tests/unit/sdk/context/test_llmcompactionstrategy.py
+++ b/tests/unit/sdk/context/test_llmcompactionstrategy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -226,3 +227,58 @@ async def test_summary_record_includes_metadata():
     assert record.conversation_id == "conv-123"
     assert record.agent_name == "BROWSER"
     assert record.options == {"temperature": 0.3}
+
+
+# ── _unload_model (async subprocess) ────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unload_model_spawns_subprocess_and_awaits():
+    """_unload_model should use create_subprocess_exec and await communicate()."""
+    from sdk.context._strategy import _unload_model
+
+    with patch("sdk.context._strategy.asyncio.create_subprocess_exec") as mock_csp:
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_csp.return_value = mock_proc
+
+        await _unload_model("test-model")
+
+        mock_csp.assert_called_once_with(
+            "ollama", "stop", "test-model",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        mock_proc.communicate.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unload_model_handles_timeout():
+    """_unload_model should kill the process on timeout."""
+    from sdk.context._strategy import _unload_model
+
+    with patch("sdk.context._strategy.asyncio.create_subprocess_exec") as mock_csp:
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(side_effect=TimeoutError)
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+        mock_csp.return_value = mock_proc
+
+        await _unload_model("test-model")
+
+        mock_proc.kill.assert_called_once()
+        mock_proc.wait.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unload_model_handles_subprocess_error():
+    """_unload_model should catch OSError during subprocess creation."""
+    from sdk.context._strategy import _unload_model
+
+    with patch("sdk.context._strategy.asyncio.create_subprocess_exec",
+               side_effect=OSError("ollama not found")):
+        # Should not raise — the exception is caught and logged.
+        await _unload_model("test-model")


### PR DESCRIPTION
… _unload_model

- _unload_model now uses asyncio.create_subprocess_exec + communicate() with 30s timeout
- All three call sites updated to await _unload_model(...)
- Added unit tests for normal subprocess flow, timeout handling, and OSError during spawn

Found by daily automated bug scan.