### PR TITLE
fix: keep consecutive tool results together in chunk splitting

### DIFF
--- a/sdk/context/_strategy.py
+++ b/sdk/context/_strategy.py
@@ -722,17 +722,21 @@ def _would_split_tool_pair(
     tool-call / tool-result pair across chunks.
 
     Fires when *next_msg* is a tool result and the last message in
-    *chunk* is an assistant with ``tool_calls`` — flushing here would
-    put the call and its result in different chunks.
+    *chunk* is either an assistant with ``tool_calls`` or another tool
+    result — flushing here would put the call and its result(s) in
+    different chunks.
     """
     if not chunk:
         return False
 
     last = chunk[-1]
-    return (
-        next_msg.get("role") == "tool"
-        and last.get("role") == "assistant"
-        and bool(last.get("tool_calls"))
+    return next_msg.get("role") == "tool" and (
+        # Next message is a tool result and the last message in the chunk
+        # is the assistant that issued the tool call.
+        (last.get("role") == "assistant" and bool(last.get("tool_calls")))
+        # Or the last message is also a tool result — keep consecutive
+        # tool results together with their originating assistant.
+        or last.get("role") == "tool"
     )
 
 

--- a/tests/unit/sdk/context/test_split_into_chunks.py
+++ b/tests/unit/sdk/context/test_split_into_chunks.py
@@ -162,3 +162,70 @@ def test_empty_tool_calls_list_splits_normally():
     assert len(chunks) >= 2
     total = sum(len(c) for c in chunks)
     assert total == 3
+
+
+@pytest.mark.unit
+def test_second_tool_result_not_split_from_assistant():
+    """When an assistant issues two tool calls, both results stay in the
+    same chunk as the assistant — the second tool result must not be
+    pushed to a new chunk."""
+    messages = [
+        _make_msg("user", "x" * 80),
+        _make_msg(
+            "assistant",
+            content="",
+            tool_calls=[
+                {"function": {"name": "read_file", "arguments": "{}"}},
+                {"function": {"name": "grep", "arguments": "{}"}},
+            ],
+        ),
+        _make_msg("tool", content="r1" * 80, tool_name="read_file"),
+        _make_msg("tool", content="r2" * 80, tool_name="grep"),
+    ]
+    chunks = _split_into_chunks(messages, target_size=100)
+
+    # All four messages (user, assistant, tool1, tool2) must be in one chunk.
+    assert len(chunks) == 1, (
+        f"Expected 1 chunk, got {len(chunks)} — "
+        f"second tool result was split from its assistant"
+    )
+    assert len(chunks[0]) == 4
+    assert chunks[0][0]["role"] == "user"
+    assert chunks[0][1]["role"] == "assistant"
+    assert chunks[0][2]["role"] == "tool"
+    assert chunks[0][3]["role"] == "tool"
+
+
+@pytest.mark.unit
+def test_tool_result_chain_not_split():
+    """A chain of 5 tool results from one assistant all stay together."""
+    tool_names = ["t1", "t2", "t3", "t4", "t5"]
+    messages = [
+        _make_msg("user", "x" * 80),
+        _make_msg(
+            "assistant",
+            content="",
+            tool_calls=[
+                {"function": {"name": name, "arguments": "{}"}}
+                for name in tool_names
+            ],
+        ),
+    ]
+    for name in tool_names:
+        messages.append(
+            _make_msg("tool", content=f"result_{name}" * 20, tool_name=name)
+        )
+
+    chunks = _split_into_chunks(messages, target_size=100)
+
+    # All 7 messages (user + assistant + 5 tool results) must be in one chunk.
+    assert len(chunks) == 1, (
+        f"Expected 1 chunk, got {len(chunks)} — "
+        f"tool result chain was split"
+    )
+    assert len(chunks[0]) == 7
+    assert chunks[0][0]["role"] == "user"
+    assert chunks[0][1]["role"] == "assistant"
+    # Verify all 5 tool results are present and in order
+    tool_roles = [m["role"] for m in chunks[0][2:]]
+    assert tool_roles == ["tool"] * 5


### PR DESCRIPTION
## Summary

The `_would_split_tool_pair` guard in `_split_into_chunks` only prevented splitting when the next message is a tool result and the last message in the chunk is an assistant with `tool_calls`. When an assistant issues multiple tool calls (e.g., `read_file` + `grep`), the first tool result was protected but the second and subsequent results could be pushed to a new chunk because the last message in the chunk was now another tool result, not the assistant. This caused tool results to be separated from their originating assistant message, leading to incomplete or misleading context in the summarization input.

## Changes

- Extended `_would_split_tool_pair` to also return `True` when the next message is a tool result and the last message in the chunk is also a tool result — keeping all consecutive tool results together with their originating assistant.
- Added unit tests in `tests/unit/sdk/context/test_split_into_chunks.py`: `test_second_tool_result_not_split_from_assistant` and `test_tool_result_chain_not_split`.

## Testing

All 64 tests in the context module pass. The two new tests specifically verify that multiple tool results from a single assistant stay in the same chunk.

---
*Found by daily automated bug scan.*