### PR TITLE
fix: preserve ToolLoopError message in exception handler

### DIFF
--- a/sdk/turn/_execution.py
+++ b/sdk/turn/_execution.py
@@ -282,7 +282,7 @@ async def run_turn(
                 raise
             except Exception as exc:
                 logger.exception("Unhandled exception in tool loop")
-                error_msg = str(exc) if isinstance(exc, ProviderError) else "An error occurred while processing your message."
+                error_msg = str(exc) if isinstance(exc, (ProviderError, ToolLoopError)) else "An error occurred while processing your message."
                 publish_event(AgentEvent(payload=ContentPayload(type="content", content=error_msg)))
                 _publish_turn_end()
                 raise ToolLoopError(error_msg) from exc

--- a/tests/unit/sdk/turn/test_execution.py
+++ b/tests/unit/sdk/turn/test_execution.py
@@ -500,6 +500,42 @@ async def test_no_agent_state_raises() -> None:
             await run_turn(history, _make_agent())
 
 
+async def test_tool_loop_error_message_preserved_no_response() -> None:
+    """ToolLoopError("No ChatResponse received from provider") message is preserved.
+
+    When the provider yields only deltas (no ChatResponse), the inner handler
+    should preserve the original ToolLoopError message instead of replacing it
+    with the generic fallback.
+    """
+    # Provider yields only deltas — never a ChatResponse
+    streamed_turn: list[ChatDelta | ChatResponse] = [
+        ChatDelta(content="Hel"),
+        ChatDelta(content="lo"),
+    ]
+    provider = FakeProvider([streamed_turn])
+    history = ConversationHistory([{"role": "user", "content": "Hi"}])
+
+    with patch(f"{_MOD}.get_provider", return_value=provider):
+        with pytest.raises(ToolLoopError, match="No ChatResponse received from provider"):
+            await run_turn(history, _make_agent())
+
+
+async def test_tool_loop_error_message_preserved_retry_exhaustion() -> None:
+    """ToolLoopError("Failed to get chat response after retries.") message is preserved.
+
+    When _stream_chat_with_retries exhausts all retries and raises a ToolLoopError,
+    the inner handler should preserve the original message.
+    """
+    history = ConversationHistory([{"role": "user", "content": "Hi"}])
+
+    with patch(
+        f"{_MOD}._stream_chat_with_retries",
+        side_effect=ToolLoopError("Failed to get chat response after retries."),
+    ):
+        with pytest.raises(ToolLoopError, match="Failed to get chat response after retries."):
+            await run_turn(history, _make_agent())
+
+
 # ---------------------------------------------------------------------------
 # Tests: history mutation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

In `sdk/turn/_execution.py`, the inner exception handler at line 285 only preserved the original error message for `ProviderError` exceptions. When a `ToolLoopError` was raised inside the try block (e.g., when no ChatResponse was received from the provider, or when `_stream_chat_with_retries` exhausted all retries), the original diagnostic message was replaced with a generic "An error occurred while processing your message." This lost actionable error information needed to debug provider communication failures.

## Changes

- Changed the `isinstance` check from `ProviderError` to `(ProviderError, ToolLoopError)` so that `ToolLoopError` messages are also preserved.
- Added two unit tests in `tests/unit/sdk/turn/test_execution.py`:
  - `test_tool_loop_error_message_preserved_no_response` — verifies the "No ChatResponse received from provider" message is preserved
  - `test_tool_loop_error_message_preserved_retry_exhaustion` — verifies the "Failed to get chat response after retries." message is preserved

## Testing

All unit tests pass. New tests cover both the no-response and retry-exhaustion paths.

---
*Found by daily automated bug scan.*